### PR TITLE
Refactor API server with versioned DTOs and OpenAPI docs

### DIFF
--- a/api_types.go
+++ b/api_types.go
@@ -1,0 +1,140 @@
+package main
+
+import "time"
+
+// ResponseRequestV1 represents the payload for the v1 responses endpoint.
+type ResponseRequestV1 struct {
+	Model          string               `json:"model"`
+	Instructions   string               `json:"instructions,omitempty"`
+	Temperature    *float32             `json:"temperature,omitempty"`
+	ResponseFormat *ResponseFormat      `json:"response_format,omitempty"`
+	Tools          []ToolDefinition     `json:"tools,omitempty"`
+	Files          []FileReference      `json:"files,omitempty"`
+	ThreadID       string               `json:"thread_id,omitempty"`
+	RunID          string               `json:"run_id,omitempty"`
+	Input          []ResponseInputBlock `json:"input,omitempty"`
+}
+
+// ResponseInputBlock represents a block of input content provided by the caller.
+type ResponseInputBlock struct {
+	Role    string           `json:"role"`
+	Content []MessageContent `json:"content"`
+}
+
+// ResponseFormat describes how the caller would like output to be formatted.
+type ResponseFormat struct {
+	Type string `json:"type"`
+}
+
+// ToolDefinition describes a callable tool exposed to the assistant.
+type ToolDefinition struct {
+	Type     string              `json:"type"`
+	Function *FunctionDefinition `json:"function,omitempty"`
+}
+
+// FunctionDefinition describes a function tool signature.
+type FunctionDefinition struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Parameters  map[string]any `json:"parameters,omitempty"`
+}
+
+// FileReference represents an uploaded file available to the assistant.
+type FileReference struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// ResponseMessageV1 is the top-level response payload for v1 responses.
+type ResponseMessageV1 struct {
+	ID           string           `json:"id"`
+	Object       string           `json:"object"`
+	Created      int64            `json:"created"`
+	Model        string           `json:"model"`
+	Output       []ResponseOutput `json:"output"`
+	Usage        *ResponseUsage   `json:"usage,omitempty"`
+	ThreadID     string           `json:"thread_id,omitempty"`
+	RunID        string           `json:"run_id,omitempty"`
+	Instructions string           `json:"instructions,omitempty"`
+}
+
+// ResponseOutput represents the generated output blocks.
+type ResponseOutput struct {
+	ID      string           `json:"id"`
+	Type    string           `json:"type"`
+	Role    string           `json:"role,omitempty"`
+	Status  string           `json:"status"`
+	Content []MessageContent `json:"content"`
+}
+
+// MessageContent represents text-based content.
+type MessageContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// ResponseUsage mirrors the usage block returned by OpenAI.
+type ResponseUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
+// ThreadRequestV1 represents the payload for creating a thread.
+type ThreadRequestV1 struct {
+	Title         string            `json:"title,omitempty"`
+	Instructions  string            `json:"instructions,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	ToolResources map[string]any    `json:"tool_resources,omitempty"`
+}
+
+// ThreadResponseV1 is returned after creating a thread.
+type ThreadResponseV1 struct {
+	ID            string            `json:"id"`
+	Object        string            `json:"object"`
+	CreatedAt     time.Time         `json:"created_at"`
+	Title         string            `json:"title,omitempty"`
+	Instructions  string            `json:"instructions,omitempty"`
+	Metadata      map[string]string `json:"metadata,omitempty"`
+	ToolResources map[string]any    `json:"tool_resources,omitempty"`
+	Status        string            `json:"status"`
+}
+
+// AssistantRequestV1 represents the payload for creating an assistant.
+type AssistantRequestV1 struct {
+	Name         string            `json:"name"`
+	Model        string            `json:"model"`
+	Instructions string            `json:"instructions,omitempty"`
+	Tools        []ToolDefinition  `json:"tools,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// AssistantResponseV1 describes the assistant resource.
+type AssistantResponseV1 struct {
+	ID           string            `json:"id"`
+	Object       string            `json:"object"`
+	CreatedAt    time.Time         `json:"created_at"`
+	Name         string            `json:"name"`
+	Model        string            `json:"model"`
+	Instructions string            `json:"instructions,omitempty"`
+	Tools        []ToolDefinition  `json:"tools,omitempty"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// VectorStoreRequestV1 represents the payload for creating a vector store.
+type VectorStoreRequestV1 struct {
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// VectorStoreResponseV1 represents the resulting vector store resource.
+type VectorStoreResponseV1 struct {
+	ID          string            `json:"id"`
+	Object      string            `json:"object"`
+	CreatedAt   time.Time         `json:"created_at"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Status      string            `json:"status"`
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,564 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "GBT Assistant API",
+    "version": "1.0.0",
+    "description": "REST API for orchestrating OpenAI-powered agent workflows."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8080",
+      "description": "Local development"
+    }
+  ],
+  "paths": {
+    "/v1/responses": {
+      "post": {
+        "summary": "Create a model response",
+        "operationId": "createResponse",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResponseRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Response generated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResponseMessageV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Upstream service failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/threads": {
+      "post": {
+        "summary": "Create a new conversation thread",
+        "operationId": "createThread",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Thread created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/assistants": {
+      "post": {
+        "summary": "Create a reusable assistant profile",
+        "operationId": "createAssistant",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssistantRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Assistant created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssistantResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/vector-stores": {
+      "post": {
+        "summary": "Create a vector store",
+        "operationId": "createVectorStore",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VectorStoreRequestV1"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Vector store created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VectorStoreResponseV1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ResponseRequestV1": {
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "Model identifier to use for generation."
+          },
+          "instructions": {
+            "type": "string",
+            "description": "System level instructions for the assistant."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "minimum": 0,
+            "maximum": 2,
+            "description": "Sampling temperature between 0 and 2."
+          },
+          "response_format": {
+            "$ref": "#/components/schemas/ResponseFormat"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolDefinition"
+            }
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FileReference"
+            }
+          },
+          "thread_id": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "input": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResponseInputBlock"
+            }
+          }
+        }
+      },
+      "ResponseInputBlock": {
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "description": "Role of the message author (system, user, assistant)."
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageContent"
+            }
+          }
+        }
+      },
+      "ResponseFormat": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Desired output format (e.g. text or json_object)."
+          }
+        }
+      },
+      "ToolDefinition": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "Type of tool such as function."
+          },
+          "function": {
+            "$ref": "#/components/schemas/FunctionDefinition"
+          }
+        }
+      },
+      "FunctionDefinition": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "FileReference": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ResponseMessageV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "model": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "thread_id": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "output": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResponseOutput"
+            }
+          },
+          "usage": {
+            "$ref": "#/components/schemas/ResponseUsage"
+          }
+        }
+      },
+      "ResponseOutput": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageContent"
+            }
+          }
+        }
+      },
+      "MessageContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "ResponseUsage": {
+        "type": "object",
+        "properties": {
+          "prompt_tokens": {
+            "type": "integer"
+          },
+          "completion_tokens": {
+            "type": "integer"
+          },
+          "total_tokens": {
+            "type": "integer"
+          }
+        }
+      },
+      "ThreadRequestV1": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "additionalProperties": {}
+          }
+        }
+      },
+      "ThreadResponseV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tool_resources": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "AssistantRequestV1": {
+        "type": "object",
+        "required": [
+          "name",
+          "model"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolDefinition"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AssistantResponseV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "instructions": {
+            "type": "string"
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ToolDefinition"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VectorStoreRequestV1": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VectorStoreResponseV1": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs_embed.go
+++ b/docs_embed.go
@@ -1,0 +1,6 @@
+package main
+
+import _ "embed"
+
+//go:embed docs/openapi.json
+var openAPISpec []byte

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,10 @@ go 1.20
 
 require (
 	github.com/gocolly/colly v1.2.0
+	github.com/google/uuid v1.3.1
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.5.1
+	github.com/marcboeker/go-duckdb v1.4.4
 	github.com/rs/cors v1.9.0
 	github.com/sashabaranov/go-openai v1.9.5
 	github.com/twilio/twilio-go v1.7.1
@@ -22,7 +24,6 @@ require (
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/kennygrant/sanitize v1.2.4 // indirect
-	github.com/marcboeker/go-duckdb v1.4.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=

--- a/main.go
+++ b/main.go
@@ -1,157 +1,44 @@
 package main
 
 import (
-	"context"
 	"log"
 	"net/http"
 	"os"
-	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
 	"github.com/rs/cors"
-
 	"github.com/sashabaranov/go-openai"
-	//"github.com/joho/godotenv"
-	//gogpt "github.com/sashabaranov/go-gpt3"
 )
-
-type Input struct {
-	client                       *openai.Client
-	prompt, model, systemMessage string
-	temperature                  float32
-	maxTokens                    int
-	res                          string // maybe this could be a generic so that it can be both a slice, string or a null
-}
-
-type Plugin struct {
-}
-
-/*
-	/
-
-/ the string to be encoded
-
-	str := "This is an example sentence to try encoding out on!"
-
-	result, err := encode(str)
-	if err != nil {
-		log.Fatalf("Encoding failed: %v", err)
-	}
-
-	// print the encoded string and token count
-	fmt.Printf("Encoded tokens: %v\n", result.Tokens)
-	fmt.Printf("Token count: %d\n", result.
-)
-
-*
-*/
 
 func main() {
-	// Enable CORS with allowed origins
-	c := cors.New(cors.Options{
-		AllowedOrigins: []string{"http://localhost:3000"},
-		AllowedMethods: []string{"POST"},
-		AllowedHeaders: []string{"Content-Type"},
-	})
+	if err := godotenv.Load(); err != nil {
+		log.Println("warning: could not load .env file", err)
+	}
 
-	handler := c.Handler(http.HandlerFunc(handleRequest))
+	apiKey := os.Getenv("OPENAI_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENAI_KEY environment variable is not set")
+	}
+
+	client := openai.NewClient(apiKey)
+	wrapper := NewOpenAIWrapper(client)
+	server := NewAPIServer(wrapper)
+
+	router := mux.NewRouter()
+	router.HandleFunc("/v1/responses", server.handleCreateResponse).Methods(http.MethodPost)
+	router.HandleFunc("/v1/threads", server.handleCreateThread).Methods(http.MethodPost)
+	router.HandleFunc("/v1/assistants", server.handleCreateAssistant).Methods(http.MethodPost)
+	router.HandleFunc("/v1/vector-stores", server.handleCreateVectorStore).Methods(http.MethodPost)
+	router.HandleFunc("/openapi.json", server.handleOpenAPIDocument).Methods(http.MethodGet)
+	router.HandleFunc("/swagger.json", server.handleOpenAPIDocument).Methods(http.MethodGet)
+
+	corsHandler := cors.New(cors.Options{
+		AllowedOrigins: []string{"http://localhost:3000"},
+		AllowedMethods: []string{http.MethodGet, http.MethodPost, http.MethodOptions},
+		AllowedHeaders: []string{"Content-Type", "Authorization"},
+	}).Handler(router)
 
 	log.Println("Server listening on port 8080...")
-	log.Fatal(http.ListenAndServe(":8080", handler))
-}
-
-func getClient() *openai.Client {
-	// Get the OpenAI API key from the .env file
-	if err := godotenv.Load(); err != nil {
-		log.Println("error loading .env file:", err)
-	}
-
-	var key string = os.Getenv("OPENAI_KEY")
-
-	return openai.NewClient(key)
-}
-
-func (inp Input) getChatStreamResponse() (string, error) {
-	var array = []openai.ChatCompletionMessage{
-		{
-			Role:    "system",
-			Content: inp.systemMessage,
-		},
-		{
-			Role:    "user",
-			Content: inp.prompt,
-		},
-	}
-
-	request := openai.ChatCompletionRequest{
-		Model:           inp.model,
-		Messages:        array,
-		MaxTokens:       inp.maxTokens,
-		Temperature:     inp.temperature,
-		TopP:            1,
-		PresencePenalty: 0.6,
-		Stop:            []string{"user:", "assistant:"},
-	}
-
-	stream, err := inp.client.CreateChatCompletionStream(context.Background(), request)
-	if err != nil {
-		log.Println(err, "createchatcompletionstream")
-		return "", err
-	}
-	defer stream.Close()
-
-	var buffer strings.Builder
-	for {
-		response, err := stream.Recv()
-		if err != nil {
-			log.Println(err, "stream.Recv()")
-			return "", err
-		}
-
-		if len(response.Choices) > 0 {
-			choice := response.Choices[0]
-			buffer.WriteString(choice.Delta.Content)
-		}
-
-		if response.Choices[0].FinishReason != "" {
-			break
-		}
-	}
-
-	return buffer.String(), nil
-}
-
-func getStreamResponse(prompt string, g *openai.Client) (string, error) {
-	request := openai.CompletionRequest{
-		Model:     "text-ada-001",
-		MaxTokens: 500,
-		Prompt:    prompt,
-		Stream:    true,
-		//Stop:            []string{"human:", "ai:"},
-		//Temperature:     0,
-		//TopP:            1,
-		//PresencePenalty: 0.6,
-	}
-
-	stream, err := g.CreateCompletionStream(context.Background(), request)
-	if err != nil {
-		return "", err
-	}
-	defer stream.Close()
-
-	var buffer strings.Builder
-	for {
-		response, err := stream.Recv()
-		if err != nil {
-			return "", err
-		}
-
-		buffer.WriteString(response.Choices[0].Text)
-
-		if response.Choices[0].FinishReason != "" {
-			break
-		}
-	}
-
-	return buffer.String(), nil
+	log.Fatal(http.ListenAndServe(":8080", corsHandler))
 }

--- a/openai_wrapper.go
+++ b/openai_wrapper.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sashabaranov/go-openai"
+)
+
+var (
+	errMissingModel    = errors.New("model is required")
+	errMissingInput    = errors.New("instructions or input content is required")
+	errAssistantName   = errors.New("assistant name is required")
+	errVectorStoreName = errors.New("vector store name is required")
+)
+
+// OpenAIWrapper centralises interactions with the OpenAI client so handlers can remain thin.
+type OpenAIWrapper struct {
+	client *openai.Client
+}
+
+// NewOpenAIWrapper constructs a new wrapper using the provided OpenAI client.
+func NewOpenAIWrapper(client *openai.Client) *OpenAIWrapper {
+	return &OpenAIWrapper{client: client}
+}
+
+// CreateResponse issues a chat completion request and maps the result to the v1 response DTO.
+func (o *OpenAIWrapper) CreateResponse(ctx context.Context, req ResponseRequestV1) (ResponseMessageV1, error) {
+	if req.Model == "" {
+		return ResponseMessageV1{}, errMissingModel
+	}
+
+	messages := buildMessages(req)
+	if len(messages) == 0 {
+		return ResponseMessageV1{}, errMissingInput
+	}
+
+	temperature := float32(0.7)
+	if req.Temperature != nil {
+		temperature = *req.Temperature
+	}
+
+	completionReq := openai.ChatCompletionRequest{
+		Model:       req.Model,
+		Messages:    messages,
+		Temperature: temperature,
+	}
+
+	completion, err := o.client.CreateChatCompletion(ctx, completionReq)
+	if err != nil {
+		return ResponseMessageV1{}, fmt.Errorf("create chat completion: %w", err)
+	}
+
+	output := make([]ResponseOutput, 0, len(completion.Choices))
+	for _, choice := range completion.Choices {
+		content := []MessageContent{
+			{
+				Type: "output_text",
+				Text: choice.Message.Content,
+			},
+		}
+
+		output = append(output, ResponseOutput{
+			ID:      fmt.Sprintf("msg_%s", uuid.New().String()),
+			Type:    "message",
+			Role:    choice.Message.Role,
+			Status:  "completed",
+			Content: content,
+		})
+	}
+
+	usage := &ResponseUsage{
+		PromptTokens:     completion.Usage.PromptTokens,
+		CompletionTokens: completion.Usage.CompletionTokens,
+		TotalTokens:      completion.Usage.TotalTokens,
+	}
+
+	response := ResponseMessageV1{
+		ID:           completion.ID,
+		Object:       "response",
+		Created:      completion.Created,
+		Model:        completion.Model,
+		Output:       output,
+		Usage:        usage,
+		ThreadID:     req.ThreadID,
+		RunID:        req.RunID,
+		Instructions: req.Instructions,
+	}
+
+	return response, nil
+}
+
+// CreateThread materialises a thread resource locally so the front-end can coordinate runs.
+func (o *OpenAIWrapper) CreateThread(_ context.Context, req ThreadRequestV1) (ThreadResponseV1, error) {
+	response := ThreadResponseV1{
+		ID:            fmt.Sprintf("thread_%s", uuid.New().String()),
+		Object:        "thread",
+		CreatedAt:     time.Now().UTC(),
+		Title:         req.Title,
+		Instructions:  req.Instructions,
+		Metadata:      req.Metadata,
+		ToolResources: req.ToolResources,
+		Status:        "open",
+	}
+
+	return response, nil
+}
+
+// CreateAssistant materialises an assistant resource locally.
+func (o *OpenAIWrapper) CreateAssistant(_ context.Context, req AssistantRequestV1) (AssistantResponseV1, error) {
+	if req.Name == "" {
+		return AssistantResponseV1{}, errAssistantName
+	}
+	if req.Model == "" {
+		return AssistantResponseV1{}, errMissingModel
+	}
+
+	response := AssistantResponseV1{
+		ID:           fmt.Sprintf("asst_%s", uuid.New().String()),
+		Object:       "assistant",
+		CreatedAt:    time.Now().UTC(),
+		Name:         req.Name,
+		Model:        req.Model,
+		Instructions: req.Instructions,
+		Tools:        req.Tools,
+		Metadata:     req.Metadata,
+	}
+
+	return response, nil
+}
+
+// CreateVectorStore materialises a vector store resource locally.
+func (o *OpenAIWrapper) CreateVectorStore(_ context.Context, req VectorStoreRequestV1) (VectorStoreResponseV1, error) {
+	if req.Name == "" {
+		return VectorStoreResponseV1{}, errVectorStoreName
+	}
+
+	response := VectorStoreResponseV1{
+		ID:          fmt.Sprintf("vs_%s", uuid.New().String()),
+		Object:      "vector_store",
+		CreatedAt:   time.Now().UTC(),
+		Name:        req.Name,
+		Description: req.Description,
+		Metadata:    req.Metadata,
+		Status:      "ready",
+	}
+
+	return response, nil
+}
+
+func buildMessages(req ResponseRequestV1) []openai.ChatCompletionMessage {
+	messages := make([]openai.ChatCompletionMessage, 0)
+
+	if req.Instructions != "" {
+		messages = append(messages, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleSystem,
+			Content: req.Instructions,
+		})
+	}
+
+	for _, block := range req.Input {
+		if block.Role == "" {
+			continue
+		}
+		text := concatenateContent(block.Content)
+		if text == "" {
+			continue
+		}
+		messages = append(messages, openai.ChatCompletionMessage{
+			Role:    block.Role,
+			Content: text,
+		})
+	}
+
+	hasUser := false
+	for _, msg := range messages {
+		if msg.Role == openai.ChatMessageRoleUser {
+			hasUser = true
+			break
+		}
+	}
+
+	if !hasUser && req.Instructions != "" {
+		messages = append(messages, openai.ChatCompletionMessage{
+			Role:    openai.ChatMessageRoleUser,
+			Content: req.Instructions,
+		})
+	}
+
+	return messages
+}
+
+func concatenateContent(content []MessageContent) string {
+	if len(content) == 0 {
+		return ""
+	}
+
+	var result string
+	for _, block := range content {
+		if block.Text == "" {
+			continue
+		}
+		result += block.Text
+	}
+
+	return result
+}

--- a/server.go
+++ b/server.go
@@ -2,52 +2,198 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
 )
 
-type Request struct {
-	Query string `json:"query"`
+// APIServer orchestrates HTTP request handling and response rendering.
+type APIServer struct {
+	openai *OpenAIWrapper
 }
 
-type Response struct {
-	Result string `json:"result"`
+// NewAPIServer constructs a new server instance.
+func NewAPIServer(openai *OpenAIWrapper) *APIServer {
+	return &APIServer{openai: openai}
 }
 
-func handleRequest(w http.ResponseWriter, r *http.Request) {
-	// Set CORS headers before writing response
-	w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
-	w.Header().Set("Access-Control-Allow-Methods", "POST")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-
-	// Only allow POST requests
-	//if r.Method != http.MethodPost {
-	//	w.WriteHeader(http.StatusMethodNotAllowed)
-	//	return
-	//}
-
-	// Parse the JSON payload
-	var req Request
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+func (s *APIServer) handleCreateResponse(w http.ResponseWriter, r *http.Request) {
+	var req ResponseRequestV1
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	inp := Input{client: getClient(), prompt: req.Query + "\n", model: "gpt-3.5-turbo-0613", temperature: 0.7, maxTokens: 250, systemMessage: `You are a gardening assistant. You provide concise and thoughtful answers to gardening topics.`}
-
-	res, err := inp.getChatStreamResponse()
-	_ = err
-
-	resp := Response{Result: res}
-
-	// Convert the response object to JSON
-	respJSON, err := json.Marshal(resp)
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
+	if err := validateResponseRequest(req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	// Set the content type and send the response
+	response, err := s.openai.CreateResponse(r.Context(), req)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (s *APIServer) handleCreateThread(w http.ResponseWriter, r *http.Request) {
+	var req ThreadRequestV1
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	response, err := s.openai.CreateThread(r.Context(), req)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func (s *APIServer) handleCreateAssistant(w http.ResponseWriter, r *http.Request) {
+	var req AssistantRequestV1
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := validateAssistantRequest(req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	response, err := s.openai.CreateAssistant(r.Context(), req)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func (s *APIServer) handleCreateVectorStore(w http.ResponseWriter, r *http.Request) {
+	var req VectorStoreRequestV1
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := validateVectorStoreRequest(req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	response, err := s.openai.CreateVectorStore(r.Context(), req)
+	if err != nil {
+		handleServiceError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func (s *APIServer) handleOpenAPIDocument(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(respJSON)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(openAPISpec)
+}
+
+func decodeJSON(r *http.Request, target any) error {
+	defer r.Body.Close()
+
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("invalid JSON payload: %w", err)
+	}
+
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return errors.New("invalid JSON payload: multiple documents not supported")
+	}
+
+	return nil
+}
+
+func validateResponseRequest(req ResponseRequestV1) error {
+	if req.Model == "" {
+		return errors.New("model is required")
+	}
+
+	if req.Temperature != nil {
+		if *req.Temperature < 0 || *req.Temperature > 2 {
+			return errors.New("temperature must be between 0 and 2")
+		}
+	}
+
+	if req.Instructions == "" && len(req.Input) == 0 {
+		return errors.New("instructions or input is required")
+	}
+
+	for i, block := range req.Input {
+		if block.Role == "" {
+			return fmt.Errorf("input[%d].role is required", i)
+		}
+		if len(block.Content) == 0 {
+			return fmt.Errorf("input[%d].content must include at least one entry", i)
+		}
+		for j, content := range block.Content {
+			if content.Text == "" {
+				return fmt.Errorf("input[%d].content[%d].text is required", i, j)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateAssistantRequest(req AssistantRequestV1) error {
+	if req.Name == "" {
+		return errors.New("name is required")
+	}
+	if req.Model == "" {
+		return errors.New("model is required")
+	}
+	return nil
+}
+
+func validateVectorStoreRequest(req VectorStoreRequestV1) error {
+	if req.Name == "" {
+		return errors.New("name is required")
+	}
+	return nil
+}
+
+func handleServiceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errMissingModel), errors.Is(err, errMissingInput), errors.Is(err, errAssistantName), errors.Is(err, errVectorStoreName):
+		writeError(w, http.StatusBadRequest, err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "upstream error: "+err.Error())
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to encode response")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error": message,
+	})
 }


### PR DESCRIPTION
## Summary
- replace the legacy request/response structs with versioned v1 DTOs covering instructions, files, tools, and resource metadata
- add an OpenAI client wrapper and split HTTP handlers across /v1/responses, /v1/threads, /v1/assistants, and /v1/vector-stores with validation-driven error handling
- publish an embedded OpenAPI 3.0 specification to document the new surface area for downstream consumers

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cbc66d69a48328af2bb87cbe5bf722