### PR TITLE
Rename DuckDB connector helper

### DIFF
--- a/duckdb.go
+++ b/duckdb.go
@@ -23,7 +23,8 @@ type user struct {
 	bday    time.Time
 }
 
-func duckdb_connect() {
+// connectDuckDB opens a DuckDB database and demonstrates basic operations.
+func connectDuckDB() {
 	// Use second argument to store DB on disk
 	// db, err := sql.Open("duckdb", "foobar.db")
 


### PR DESCRIPTION
## Summary
- rename the DuckDB connection helper to the camelCase name `connectDuckDB`
- update the helper comment to read naturally with the new identifier

## Testing
- go fmt duckdb.go
- go test ./... *(fails: missing github.com/pkoukk/tiktoken-go and github.com/pkoukk/tiktoken-go-loader modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aa0e80e48328b3d43ae5f03164a9