### PR TITLE
Document corpus helper and add character count tests

### DIFF
--- a/corpus.go
+++ b/corpus.go
@@ -2,11 +2,9 @@ package main
 
 // global variable of the corpus need to uploaded to a db
 
-// todo: to use a doc to extract
-// todo: every 4000 charectors need to added a slice along with a struct of attributes of the document
-
-func getCountOfChars(doc1 string) {
-	countChars(doc1)
+// getCountOfChars returns the number of Unicode characters in the provided document.
+func getCountOfChars(doc1 string) int {
+	return countChars(doc1)
 }
 
 func countChars(s string) int {

--- a/corpus_test.go
+++ b/corpus_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestGetCountOfCharsASCII(t *testing.T) {
+	doc := "hello world"
+	want := 11
+
+	if got := getCountOfChars(doc); got != want {
+		t.Errorf("getCountOfChars(%q) = %d, want %d", doc, got, want)
+	}
+
+	if got := countChars(doc); got != want {
+		t.Errorf("countChars(%q) = %d, want %d", doc, got, want)
+	}
+}
+
+func TestGetCountOfCharsMultibyte(t *testing.T) {
+	doc := "こんにちは世界"
+	want := 7
+
+	if got := getCountOfChars(doc); got != want {
+		t.Errorf("getCountOfChars(%q) = %d, want %d", doc, got, want)
+	}
+
+	if got := countChars(doc); got != want {
+		t.Errorf("countChars(%q) = %d, want %d", doc, got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- document the corpus helper and make `getCountOfChars` return the rune count from `countChars`
- add ASCII and multi-byte coverage for both counting helpers

## Testing
- gofmt -w corpus.go corpus_test.go
- go test ./... *(fails: missing github.com/pkoukk/tiktoken-go modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e2aa0d839083289a4218889955d38d