### PR TITLE
Add prompt evaluation pipeline backed by DuckDB

### DIFF
--- a/internal/api/prompt_evaluation_types.go
+++ b/internal/api/prompt_evaluation_types.go
@@ -1,0 +1,78 @@
+package api
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// PromptEvaluationRequest captures the payload for requesting a prompt critique
+// and improvement.
+type PromptEvaluationRequest struct {
+	Prompt          string                 `json:"prompt"`
+	TargetModel     string                 `json:"target_model"`
+	EvaluationModel string                 `json:"evaluation_model,omitempty"`
+	ResearchTopics  []string               `json:"research_topics,omitempty"`
+	MaxContext      int                    `json:"max_context,omitempty"`
+	Backend         *PromptBackendOverride `json:"backend,omitempty"`
+	Metadata        map[string]string      `json:"metadata,omitempty"`
+}
+
+// PromptBackendOverride mirrors the backend override options exposed by the
+// prompt service allowing callers to direct evaluations to alternative model
+// endpoints.
+type PromptBackendOverride struct {
+	BaseURL string            `json:"base_url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
+}
+
+// Validate performs minimal validation on the request payload.
+func (r *PromptEvaluationRequest) Validate() error {
+	if r == nil {
+		return errors.New("request body is required")
+	}
+	if strings.TrimSpace(r.Prompt) == "" {
+		return errors.New("prompt is required")
+	}
+	if strings.TrimSpace(r.TargetModel) == "" {
+		return errors.New("target_model is required")
+	}
+	if r.MaxContext < 0 {
+		return errors.New("max_context must be zero or positive")
+	}
+	if r.Backend != nil {
+		for key := range r.Backend.Headers {
+			if strings.TrimSpace(key) == "" {
+				return errors.New("backend.headers keys must be non-empty")
+			}
+		}
+	}
+	return nil
+}
+
+// PromptEvaluationResponse returns the improved prompt and evaluation metadata.
+type PromptEvaluationResponse struct {
+	EvaluationID    string                  `json:"evaluation_id"`
+	TargetModel     string                  `json:"target_model"`
+	EvaluationModel string                  `json:"evaluation_model"`
+	OriginalPrompt  string                  `json:"original_prompt"`
+	ImprovedPrompt  string                  `json:"improved_prompt"`
+	Critique        string                  `json:"critique,omitempty"`
+	Scores          map[string]float64      `json:"scores"`
+	Suggestions     []string                `json:"suggestions,omitempty"`
+	ResearchContext []PromptResearchContext `json:"research_context"`
+	RawModelOutput  string                  `json:"raw_model_output"`
+	Metadata        map[string]string       `json:"metadata,omitempty"`
+	CreatedAt       time.Time               `json:"created_at"`
+}
+
+// PromptResearchContext mirrors the repository research context for API
+// responses.
+type PromptResearchContext struct {
+	ID          string    `json:"id"`
+	TargetModel string    `json:"target_model,omitempty"`
+	Topic       string    `json:"topic,omitempty"`
+	Content     string    `json:"content"`
+	Source      string    `json:"source,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/api/prompt_evaluations_handler.go
+++ b/internal/api/prompt_evaluations_handler.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"guava/internal/prompt"
+)
+
+// PromptEvaluationHandler exposes the HTTP surface for evaluating prompts.
+type PromptEvaluationHandler struct {
+	evaluator prompt.Evaluator
+	logger    *slog.Logger
+}
+
+// NewPromptEvaluationHandler constructs a handler with the provided evaluator.
+func NewPromptEvaluationHandler(evaluator prompt.Evaluator, logger *slog.Logger) *PromptEvaluationHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PromptEvaluationHandler{evaluator: evaluator, logger: logger}
+}
+
+// HandleEvaluatePrompt accepts POST requests for /v1/prompt-evaluations.
+func (h *PromptEvaluationHandler) HandleEvaluatePrompt(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST, OPTIONS")
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	if h.evaluator == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "prompt evaluation service not configured")
+		return
+	}
+
+	var req PromptEvaluationRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, fmt.Sprintf("invalid JSON payload: %v", err))
+		return
+	}
+
+	if err := req.Validate(); err != nil {
+		writeJSONError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	input := prompt.EvaluationInput{
+		Prompt:          req.Prompt,
+		TargetModel:     req.TargetModel,
+		EvaluationModel: req.EvaluationModel,
+		ResearchTopics:  req.ResearchTopics,
+		MaxContext:      req.MaxContext,
+		Metadata:        req.Metadata,
+	}
+	if req.Backend != nil {
+		input.Backend = &prompt.BackendOverride{
+			BaseURL: req.Backend.BaseURL,
+			Headers: req.Backend.Headers,
+		}
+	}
+
+	result, err := h.evaluator.EvaluatePrompt(r.Context(), input)
+	if err != nil {
+		status := http.StatusBadGateway
+		if errors.Is(err, prompt.ErrInvalidInput) {
+			status = http.StatusBadRequest
+		}
+		h.logger.Error("evaluate prompt", slog.String("error", err.Error()))
+		writeJSONError(w, status, "failed to evaluate prompt")
+		return
+	}
+
+	resp := PromptEvaluationResponse{
+		EvaluationID:    result.EvaluationID,
+		TargetModel:     result.TargetModel,
+		EvaluationModel: result.EvaluationModel,
+		OriginalPrompt:  result.OriginalPrompt,
+		ImprovedPrompt:  result.ImprovedPrompt,
+		Critique:        result.Critique,
+		Scores:          result.Scores,
+		Suggestions:     result.Suggestions,
+		RawModelOutput:  result.RawModelOutput,
+		Metadata:        result.Metadata,
+		CreatedAt:       result.CreatedAt,
+	}
+	resp.ResearchContext = make([]PromptResearchContext, 0, len(result.ResearchContext))
+	for _, ctxItem := range result.ResearchContext {
+		resp.ResearchContext = append(resp.ResearchContext, PromptResearchContext{
+			ID:          ctxItem.ID,
+			TargetModel: ctxItem.TargetModel,
+			Topic:       ctxItem.Topic,
+			Content:     ctxItem.Content,
+			Source:      ctxItem.Source,
+			CreatedAt:   ctxItem.CreatedAt,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/openaiclient/client.go
+++ b/internal/openaiclient/client.go
@@ -86,6 +86,7 @@ func (c *Client) Responses() ResponsesClient {
 // with the Responses API.
 type ResponsesClient interface {
 	CreateResponse(ctx context.Context, params responses.ResponseNewParams) (*ResponseResult, error)
+	CreateResponseWithOptions(ctx context.Context, params responses.ResponseNewParams, opts ...option.RequestOption) (*ResponseResult, error)
 	StreamResponse(ctx context.Context, params responses.ResponseNewParams) (ResponseStream, error)
 }
 
@@ -103,6 +104,14 @@ type responsesClient struct {
 
 func (c *responsesClient) CreateResponse(ctx context.Context, params responses.ResponseNewParams) (*ResponseResult, error) {
 	resp, err := c.svc.New(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return &ResponseResult{Response: resp, OutputText: resp.OutputText()}, nil
+}
+
+func (c *responsesClient) CreateResponseWithOptions(ctx context.Context, params responses.ResponseNewParams, opts ...option.RequestOption) (*ResponseResult, error) {
+	resp, err := c.svc.New(ctx, params, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/prompt/repository.go
+++ b/internal/prompt/repository.go
@@ -1,0 +1,278 @@
+package prompt
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Repository defines the persistence operations required by the prompt evaluation
+// service. Implementations are expected to provide DuckDB backed storage so that
+// research context, evaluation metadata, and model transcripts can be recorded
+// for future analysis.
+type Repository interface {
+	// ListResearchContext returns the stored research snippets that are
+	// relevant for the provided model and optional topics. The limit controls
+	// how many records are returned and should be treated as a best effort
+	// maximum.
+	ListResearchContext(ctx context.Context, targetModel string, topics []string, limit int) ([]ResearchContext, error)
+	// SavePromptEvaluation persists the result of an evaluation run including
+	// the raw model output and any research references that informed the
+	// critique.
+	SavePromptEvaluation(ctx context.Context, record PromptEvaluationRecord) error
+}
+
+// ResearchContext represents a single item of stored research that can be fed
+// into the prompt evaluator to give it additional grounding when critiquing a
+// prompt.
+type ResearchContext struct {
+	ID          string
+	TargetModel string
+	Topic       string
+	Content     string
+	Source      string
+	CreatedAt   time.Time
+}
+
+// ResearchReference records which research items informed a particular
+// evaluation. This allows downstream consumers to reconstruct the provenance of
+// the resulting prompt improvements.
+type ResearchReference struct {
+	ContextID string
+	Topic     string
+	Content   string
+	Source    string
+}
+
+// PromptEvaluationRecord captures everything needed to persist an evaluation
+// run for later analysis.
+type PromptEvaluationRecord struct {
+	EvaluationID    string
+	TargetModel     string
+	EvaluationModel string
+	OriginalPrompt  string
+	ImprovedPrompt  string
+	Critique        string
+	Scores          map[string]float64
+	Suggestions     []string
+	RawModelOutput  string
+	Metadata        map[string]string
+	References      []ResearchReference
+	CreatedAt       time.Time
+}
+
+// DuckDBRepository implements the Repository interface using a DuckDB
+// connection. It lazily creates the required tables if they do not already
+// exist.
+type DuckDBRepository struct {
+	db *sql.DB
+}
+
+// NewDuckDBRepository constructs a DuckDB backed repository. The provided
+// database connection should remain open for the lifetime of the repository.
+func NewDuckDBRepository(db *sql.DB) (*DuckDBRepository, error) {
+	if db == nil {
+		return nil, errors.New("duckdb connection is required")
+	}
+
+	repo := &DuckDBRepository{db: db}
+	if err := repo.ensureSchema(context.Background()); err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+func (r *DuckDBRepository) ensureSchema(ctx context.Context) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS prompt_research_contexts (
+                        id TEXT PRIMARY KEY,
+                        target_model TEXT,
+                        topic TEXT,
+                        content TEXT NOT NULL,
+                        source TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );`,
+		`CREATE TABLE IF NOT EXISTS prompt_evaluations (
+                        id TEXT PRIMARY KEY,
+                        target_model TEXT NOT NULL,
+                        evaluation_model TEXT NOT NULL,
+                        original_prompt TEXT NOT NULL,
+                        improved_prompt TEXT NOT NULL,
+                        critique TEXT,
+                        scores JSON,
+                        suggestions JSON,
+                        raw_model_output TEXT,
+                        metadata JSON,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                );`,
+		`CREATE TABLE IF NOT EXISTS prompt_evaluation_references (
+                        evaluation_id TEXT NOT NULL,
+                        context_id TEXT,
+                        topic TEXT,
+                        content TEXT,
+                        source TEXT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        FOREIGN KEY (evaluation_id) REFERENCES prompt_evaluations(id)
+                );`,
+	}
+
+	for _, stmt := range stmts {
+		if _, err := r.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("create duckdb schema: %w", err)
+		}
+	}
+	return nil
+}
+
+// ListResearchContext fetches research snippets for the provided model/topic
+// combination ordered by recency.
+func (r *DuckDBRepository) ListResearchContext(ctx context.Context, targetModel string, topics []string, limit int) ([]ResearchContext, error) {
+	if limit <= 0 {
+		limit = 5
+	}
+
+	var builder strings.Builder
+	builder.WriteString(`SELECT id, target_model, topic, content, source, created_at
+                FROM prompt_research_contexts
+                WHERE 1 = 1`)
+
+	args := make([]any, 0)
+	if targetModel != "" {
+		builder.WriteString(" AND (target_model = ? OR target_model IS NULL OR target_model = '')")
+		args = append(args, targetModel)
+	}
+	if len(topics) > 0 {
+		builder.WriteString(" AND topic IN (" + placeholders(len(topics)) + ")")
+		for _, topic := range topics {
+			args = append(args, topic)
+		}
+	}
+	builder.WriteString(" ORDER BY created_at DESC LIMIT ?")
+	args = append(args, limit)
+
+	rows, err := r.db.QueryContext(ctx, builder.String(), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query research context: %w", err)
+	}
+	defer rows.Close()
+
+	contexts := make([]ResearchContext, 0)
+	for rows.Next() {
+		var rc ResearchContext
+		if err := rows.Scan(&rc.ID, &rc.TargetModel, &rc.Topic, &rc.Content, &rc.Source, &rc.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan research context: %w", err)
+		}
+		contexts = append(contexts, rc)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate research context: %w", err)
+	}
+	return contexts, nil
+}
+
+// SavePromptEvaluation stores the evaluation row and associated references.
+func (r *DuckDBRepository) SavePromptEvaluation(ctx context.Context, record PromptEvaluationRecord) error {
+	if record.EvaluationID == "" {
+		return errors.New("evaluation id is required")
+	}
+	if record.CreatedAt.IsZero() {
+		record.CreatedAt = time.Now().UTC()
+	}
+
+	scoresJSON, err := json.Marshal(record.Scores)
+	if err != nil {
+		return fmt.Errorf("marshal scores: %w", err)
+	}
+	suggestionsJSON, err := json.Marshal(record.Suggestions)
+	if err != nil {
+		return fmt.Errorf("marshal suggestions: %w", err)
+	}
+	var metadataJSON []byte
+	if record.Metadata != nil {
+		metadataJSON, err = json.Marshal(record.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal metadata: %w", err)
+		}
+	}
+
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	_, err = tx.ExecContext(ctx, `
+                INSERT INTO prompt_evaluations (
+                        id, target_model, evaluation_model, original_prompt, improved_prompt,
+                        critique, scores, suggestions, raw_model_output, metadata, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+		record.EvaluationID,
+		record.TargetModel,
+		record.EvaluationModel,
+		record.OriginalPrompt,
+		record.ImprovedPrompt,
+		record.Critique,
+		string(scoresJSON),
+		string(suggestionsJSON),
+		record.RawModelOutput,
+		nullableJSONString(metadataJSON),
+		record.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("insert prompt evaluation: %w", err)
+	}
+
+	if len(record.References) > 0 {
+		stmt, prepErr := tx.PrepareContext(ctx, `
+                        INSERT INTO prompt_evaluation_references (
+                                evaluation_id, context_id, topic, content, source
+                        ) VALUES (?, ?, ?, ?, ?)
+                `)
+		if prepErr != nil {
+			return fmt.Errorf("prepare evaluation reference insert: %w", prepErr)
+		}
+		defer stmt.Close()
+
+		for _, ref := range record.References {
+			contextID := any(nil)
+			if ref.ContextID != "" {
+				contextID = ref.ContextID
+			}
+			if _, err = stmt.ExecContext(ctx, record.EvaluationID, contextID, ref.Topic, ref.Content, ref.Source); err != nil {
+				return fmt.Errorf("insert evaluation reference: %w", err)
+			}
+		}
+	}
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("commit prompt evaluation: %w", err)
+	}
+	return nil
+}
+
+func placeholders(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	items := make([]string, n)
+	for i := range items {
+		items[i] = "?"
+	}
+	return strings.Join(items, ",")
+}
+
+func nullableJSONString(data []byte) any {
+	if len(data) == 0 {
+		return nil
+	}
+	return string(data)
+}

--- a/internal/prompt/repository.go
+++ b/internal/prompt/repository.go
@@ -232,13 +232,13 @@ func (r *DuckDBRepository) SavePromptEvaluation(ctx context.Context, record Prom
 	}
 
 	if len(record.References) > 0 {
-		stmt, prepErr := tx.PrepareContext(ctx, `
+		stmt, err := tx.PrepareContext(ctx, `
                         INSERT INTO prompt_evaluation_references (
                                 evaluation_id, context_id, topic, content, source
                         ) VALUES (?, ?, ?, ?, ?)
                 `)
-		if prepErr != nil {
-			return fmt.Errorf("prepare evaluation reference insert: %w", prepErr)
+		if err != nil {
+			return fmt.Errorf("prepare evaluation reference insert: %w", err)
 		}
 		defer stmt.Close()
 

--- a/internal/prompt/service.go
+++ b/internal/prompt/service.go
@@ -1,0 +1,424 @@
+package prompt
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/responses"
+
+	"guava/internal/openaiclient"
+)
+
+var (
+	// ErrMissingResponses indicates the service cannot operate without a
+	// Responses client.
+	ErrMissingResponses = errors.New("prompt service requires responses client")
+	// ErrMissingRepository indicates the service cannot operate without a
+	// repository implementation.
+	ErrMissingRepository = errors.New("prompt service requires repository")
+	// ErrInvalidInput is returned when the caller supplies an invalid request.
+	ErrInvalidInput = errors.New("invalid prompt evaluation input")
+)
+
+// Service orchestrates prompt evaluations by combining stored research context,
+// the OpenAI Responses API, and heuristics for scoring improvements.
+type Service struct {
+	responses      openaiclient.ResponsesClient
+	repository     Repository
+	evaluatorModel string
+	logger         *slog.Logger
+}
+
+// BackendOverride allows callers to route evaluations to alternative model
+// backends such as OSS deployments by overriding the base URL or supplying
+// additional HTTP headers.
+type BackendOverride struct {
+	BaseURL string
+	Headers map[string]string
+}
+
+// ServiceConfig configures a new Service instance.
+type ServiceConfig struct {
+	Responses      openaiclient.ResponsesClient
+	Repository     Repository
+	EvaluatorModel string
+	Logger         *slog.Logger
+}
+
+// EvaluationInput captures the caller supplied data used when critiquing a
+// prompt.
+type EvaluationInput struct {
+	Prompt          string
+	TargetModel     string
+	EvaluationModel string
+	ResearchTopics  []string
+	MaxContext      int
+	Backend         *BackendOverride
+	Metadata        map[string]string
+}
+
+// EvaluationResult contains the improved prompt along with metadata describing
+// the evaluation run and supporting context.
+type EvaluationResult struct {
+	EvaluationID    string
+	TargetModel     string
+	EvaluationModel string
+	OriginalPrompt  string
+	ImprovedPrompt  string
+	Critique        string
+	Scores          map[string]float64
+	Suggestions     []string
+	ResearchContext []ResearchContext
+	RawModelOutput  string
+	Metadata        map[string]string
+	CreatedAt       time.Time
+}
+
+// Evaluator exposes the EvaluatePrompt method implemented by Service. It is
+// defined to simplify testing/mocking at the HTTP layer.
+type Evaluator interface {
+	EvaluatePrompt(ctx context.Context, input EvaluationInput) (*EvaluationResult, error)
+}
+
+// NewService constructs a new evaluator instance.
+func NewService(cfg ServiceConfig) (*Service, error) {
+	if cfg.Responses == nil {
+		return nil, ErrMissingResponses
+	}
+	if cfg.Repository == nil {
+		return nil, ErrMissingRepository
+	}
+	srv := &Service{
+		responses:      cfg.Responses,
+		repository:     cfg.Repository,
+		evaluatorModel: cfg.EvaluatorModel,
+		logger:         cfg.Logger,
+	}
+	if srv.logger == nil {
+		srv.logger = slog.Default()
+	}
+	return srv, nil
+}
+
+// EvaluatePrompt critiques the provided prompt, improves it using the configured
+// model, and returns the enriched prompt along with scoring metadata.
+func (s *Service) EvaluatePrompt(ctx context.Context, input EvaluationInput) (*EvaluationResult, error) {
+	if strings.TrimSpace(input.Prompt) == "" {
+		return nil, fmt.Errorf("%w: prompt is required", ErrInvalidInput)
+	}
+	if strings.TrimSpace(input.TargetModel) == "" {
+		return nil, fmt.Errorf("%w: target_model is required", ErrInvalidInput)
+	}
+
+	evaluationModel := input.EvaluationModel
+	if evaluationModel == "" {
+		evaluationModel = s.evaluatorModel
+	}
+	if evaluationModel == "" {
+		return nil, fmt.Errorf("%w: evaluation model is not configured", ErrInvalidInput)
+	}
+
+	contexts, err := s.repository.ListResearchContext(ctx, input.TargetModel, input.ResearchTopics, input.MaxContext)
+	if err != nil {
+		return nil, fmt.Errorf("fetch research context: %w", err)
+	}
+
+	instructions := buildInstructions(input.TargetModel)
+	payload := buildModelInput(input.Prompt, input.TargetModel, contexts, input.Metadata)
+
+	params := responses.ResponseNewParams{
+		Model:        responses.ResponsesModel(evaluationModel),
+		Input:        responses.ResponseNewParamsInputUnion{OfString: openai.String(payload)},
+		Instructions: openai.String(instructions),
+	}
+
+	opts := buildRequestOptions(input.Backend)
+
+	result, err := s.responses.CreateResponseWithOptions(ctx, params, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create evaluation response: %w", err)
+	}
+
+	feedback, err := decodeModelFeedback(result.OutputText)
+	if err != nil {
+		return nil, fmt.Errorf("parse evaluation feedback: %w", err)
+	}
+
+	if feedback.ImprovedPrompt == "" {
+		return nil, fmt.Errorf("%w: model did not return an improved_prompt", ErrInvalidInput)
+	}
+
+	scores := mergeScores(input.Prompt, feedback, contexts)
+
+	createdAt := time.Now().UTC()
+	evaluationID := uuid.NewString()
+
+	record := PromptEvaluationRecord{
+		EvaluationID:    evaluationID,
+		TargetModel:     input.TargetModel,
+		EvaluationModel: evaluationModel,
+		OriginalPrompt:  input.Prompt,
+		ImprovedPrompt:  feedback.ImprovedPrompt,
+		Critique:        feedback.Critique,
+		Scores:          scores,
+		Suggestions:     feedback.Suggestions,
+		RawModelOutput:  result.OutputText,
+		Metadata:        input.Metadata,
+		CreatedAt:       createdAt,
+	}
+	record.References = make([]ResearchReference, 0, len(contexts))
+	for _, ctxItem := range contexts {
+		record.References = append(record.References, ResearchReference{
+			ContextID: ctxItem.ID,
+			Topic:     ctxItem.Topic,
+			Content:   ctxItem.Content,
+			Source:    ctxItem.Source,
+		})
+	}
+
+	if err := s.repository.SavePromptEvaluation(ctx, record); err != nil {
+		return nil, fmt.Errorf("persist evaluation: %w", err)
+	}
+
+	return &EvaluationResult{
+		EvaluationID:    evaluationID,
+		TargetModel:     input.TargetModel,
+		EvaluationModel: evaluationModel,
+		OriginalPrompt:  input.Prompt,
+		ImprovedPrompt:  feedback.ImprovedPrompt,
+		Critique:        feedback.Critique,
+		Scores:          scores,
+		Suggestions:     feedback.Suggestions,
+		ResearchContext: contexts,
+		RawModelOutput:  result.OutputText,
+		Metadata:        input.Metadata,
+		CreatedAt:       createdAt,
+	}, nil
+}
+
+type modelFeedback struct {
+	ImprovedPrompt string             `json:"improved_prompt"`
+	Critique       string             `json:"critique"`
+	Suggestions    []string           `json:"suggestions"`
+	Scores         map[string]float64 `json:"scores"`
+}
+
+func buildInstructions(targetModel string) string {
+	var sb strings.Builder
+	sb.WriteString("You are an expert prompt engineer. Improve the supplied prompt for the target model \"")
+	sb.WriteString(targetModel)
+	sb.WriteString("\" while preserving its intent. Respond strictly in JSON with the keys improved_prompt, critique, suggestions (array), and scores (object).")
+	return sb.String()
+}
+
+func buildModelInput(prompt, targetModel string, contexts []ResearchContext, metadata map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("Target Model: ")
+	sb.WriteString(targetModel)
+	sb.WriteString("\n")
+	sb.WriteString("Original Prompt:\n")
+	sb.WriteString(prompt)
+	sb.WriteString("\n\n")
+
+	if len(contexts) > 0 {
+		sb.WriteString("Research Context:\n")
+		for i, ctxItem := range contexts {
+			sb.WriteString(fmt.Sprintf("[%d] Topic: %s\n", i+1, ctxItem.Topic))
+			sb.WriteString(ctxItem.Content)
+			if ctxItem.Source != "" {
+				sb.WriteString("\nSource: ")
+				sb.WriteString(ctxItem.Source)
+			}
+			sb.WriteString("\n---\n")
+		}
+	}
+
+	if len(metadata) > 0 {
+		keys := make([]string, 0, len(metadata))
+		for k := range metadata {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		sb.WriteString("Metadata:\n")
+		for _, key := range keys {
+			sb.WriteString(key)
+			sb.WriteString(": ")
+			sb.WriteString(metadata[key])
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("\nPlease return the JSON response now.")
+	return sb.String()
+}
+
+func buildRequestOptions(backend *BackendOverride) []option.RequestOption {
+	if backend == nil {
+		return nil
+	}
+	opts := make([]option.RequestOption, 0, 1+len(backend.Headers))
+	if backend.BaseURL != "" {
+		opts = append(opts, option.WithBaseURL(backend.BaseURL))
+	}
+	for key, value := range backend.Headers {
+		if key == "" {
+			continue
+		}
+		opts = append(opts, option.WithHeader(key, value))
+	}
+	return opts
+}
+
+func decodeModelFeedback(raw string) (*modelFeedback, error) {
+	cleaned := strings.TrimSpace(raw)
+	cleaned = strings.TrimPrefix(cleaned, "```json")
+	cleaned = strings.TrimPrefix(cleaned, "```")
+	cleaned = strings.TrimSpace(cleaned)
+	cleaned = strings.TrimSuffix(cleaned, "```")
+	cleaned = strings.TrimSpace(cleaned)
+
+	var feedback modelFeedback
+	if err := json.Unmarshal([]byte(cleaned), &feedback); err != nil {
+		return nil, err
+	}
+	if feedback.Scores == nil {
+		feedback.Scores = make(map[string]float64)
+	}
+	return &feedback, nil
+}
+
+var wordCleaner = regexp.MustCompile(`[^a-z0-9]+`)
+
+func mergeScores(originalPrompt string, feedback *modelFeedback, contexts []ResearchContext) map[string]float64 {
+	scores := make(map[string]float64, len(feedback.Scores)+4)
+	for k, v := range feedback.Scores {
+		scores[k] = clamp(v)
+	}
+
+	structureScore := computeStructureScore(feedback.ImprovedPrompt)
+	if _, ok := scores["structure"]; !ok {
+		scores["structure"] = structureScore
+	}
+
+	specificityScore := computeSpecificityScore(originalPrompt, feedback.ImprovedPrompt)
+	if _, ok := scores["specificity"]; !ok {
+		scores["specificity"] = specificityScore
+	}
+
+	supportScore := computeSupportScore(feedback.Suggestions)
+	if _, ok := scores["support"]; !ok {
+		scores["support"] = supportScore
+	}
+
+	contextScore := computeContextScore(contexts)
+	if _, ok := scores["context_alignment"]; !ok {
+		scores["context_alignment"] = contextScore
+	}
+
+	if _, ok := scores["overall"]; !ok {
+		sum := 0.0
+		for _, v := range scores {
+			sum += clamp(v)
+		}
+		if len(scores) > 0 {
+			scores["overall"] = clamp(sum / float64(len(scores)))
+		} else {
+			scores["overall"] = 0
+		}
+	}
+
+	return scores
+}
+
+func computeStructureScore(prompt string) float64 {
+	lines := strings.Split(prompt, "\n")
+	if len(lines) == 0 {
+		return 0
+	}
+	bulletCount := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			bulletCount++
+			continue
+		}
+		if len(trimmed) > 2 && trimmed[0] >= '0' && trimmed[0] <= '9' && (trimmed[1] == '.' || trimmed[1] == ')') {
+			bulletCount++
+		}
+	}
+	ratio := float64(bulletCount+1) / float64(len(lines)+1)
+	return clamp(ratio * 1.2)
+}
+
+func computeSpecificityScore(original, improved string) float64 {
+	originalWords := uniqueWords(original)
+	improvedWords := uniqueWords(improved)
+	if len(improvedWords) == 0 {
+		return 0
+	}
+	overlap := 0
+	for word := range improvedWords {
+		if _, ok := originalWords[word]; !ok {
+			overlap++
+		}
+	}
+	ratio := float64(overlap) / float64(len(improvedWords))
+	return clamp(0.5 + ratio/2)
+}
+
+func computeSupportScore(suggestions []string) float64 {
+	if len(suggestions) == 0 {
+		return 0.5
+	}
+	ratio := float64(len(suggestions)) / 5.0
+	return clamp(ratio)
+}
+
+func computeContextScore(contexts []ResearchContext) float64 {
+	if len(contexts) == 0 {
+		return 0.3
+	}
+	length := 0
+	for _, ctx := range contexts {
+		length += len(ctx.Content)
+	}
+	ratio := float64(length) / 2000.0
+	return clamp(0.6 + math.Min(0.4, ratio))
+}
+
+func uniqueWords(input string) map[string]struct{} {
+	words := strings.Fields(strings.ToLower(input))
+	out := make(map[string]struct{}, len(words))
+	for _, word := range words {
+		cleaned := wordCleaner.ReplaceAllString(word, "")
+		if cleaned == "" {
+			continue
+		}
+		out[cleaned] = struct{}{}
+	}
+	return out
+}
+
+func clamp(value float64) float64 {
+	switch {
+	case math.IsNaN(value):
+		return 0
+	case value < 0:
+		return 0
+	case value > 1:
+		return 1
+	default:
+		return value
+	}
+}


### PR DESCRIPTION
## Summary
- add a prompt evaluation service that blends stored DuckDB research context with model-driven critiques and heuristic scoring
- expose POST /v1/prompt-evaluations with request/response DTOs and handler wiring the service into the HTTP server
- extend the OpenAI client adapter to support per-request backend overrides for alternate model hosts and persist evaluation runs in DuckDB

## Testing
- go test ./... *(fails: go.mod currently contains merge conflict markers)*

------
https://chatgpt.com/codex/tasks/task_e_68e563d54d6c8328a6852899e33929df